### PR TITLE
DOCKER: Allow passing envvars when running with compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,6 @@ Migas includes the following environmental variables to allow finer control when
 | Environmental Variable | Description | Default |
 | ---- | ---- | ---- |
 | MIGAS_REQUEST_WINDOW | A sliding window for limiting number of queries (in seconds) | 60 |
-| MIGAS_REQUESTS_PER_WINDOW | Maximum number of requests per `MIGAS_REQUEST_WINDOW` | 5 |
+| MIGAS_MAX_REQUESTS_PER_WINDOW | Maximum number of requests per `MIGAS_REQUEST_WINDOW` | 5 |
 | MIGAS_MAX_REQUEST_SIZE | Maximum size of request body | 450 |
+| MIGAS_BYPASS_RATE_LIMIT | Avoid requests cap | 0 |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,11 @@ services:
     environment:
       MIGAS_REDIS_URI: "redis://cache:6379"
       DATABASE_URL: "postgresql+asyncpg://postgres:crumbs@postgres:5432/migas"
+      MIGAS_REQUEST_WINDOW:
+      MIGAS_MAX_REQUESTS_PER_WINDOW:
+      MIGAS_MAX_REQUEST_SIZE:
+      MIGAS_BYPASS_RATE_LIMIT:
+      MIGAS_DEBUG:
 
   # Redis in-memory db
   cache:


### PR DESCRIPTION
This allows the setting environmental variables when running with docker compose, e.g.
```
$ MIGAS_BYPASS_RATE_LIMIT=1 docker compose up
```