### PR TITLE
FIX: Strawberry enum name/value discrepancy

### DIFF
--- a/migas_server/tests/test_types.py
+++ b/migas_server/tests/test_types.py
@@ -2,7 +2,7 @@ import pytest
 
 from migas_server import types
 
-@pytest.mark.parametrize('names', 'val', [
+@pytest.mark.parametrize('names,val', [
     (['running', 'R'], 'R'),
     (['completed', 'C'], 'C'),
     (['failed', 'F'], 'F'),

--- a/migas_server/tests/test_types.py
+++ b/migas_server/tests/test_types.py
@@ -1,0 +1,13 @@
+import pytest
+
+from migas_server import types
+
+@pytest.mark.parametrize('names', 'val', [
+    (['running', 'R'], 'R'),
+    (['completed', 'C'], 'C'),
+    (['failed', 'F'], 'F'),
+    (['suspended', 'S'], 'S'),
+])
+def test_status(names, val):
+    for name in names:
+        assert getattr(types.Status, name).value == val

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -73,7 +73,7 @@ class Status(Enum):
     F = 'F'
     failed = strawberry.enum_value('F')
     S = 'S'
-    suspended = strawberry.enum_value('suspended')
+    suspended = strawberry.enum_value('S')
 
     # Deprecations, to be removed in 0.4.0
     pending = strawberry.enum_value('R', deprecation_reason="Pending is now running")

--- a/migas_server/types.py
+++ b/migas_server/types.py
@@ -52,32 +52,33 @@ Arguments = scalar(
 
 @strawberry.enum
 class Container(Enum):
-    unknown = 0
-    docker = 1
-    apptainer = 2
+    unknown = 'unknown'
+    docker = 'docker'
+    apptainer = 'apptainer'
 
 
 @strawberry.enum
 class User(Enum):
-    general = 0
-    dev = 1
-    ci = 2
+    general = 'general'
+    dev = 'dev'
+    ci = 'ci'
 
 
 @strawberry.enum
 class Status(Enum):
-    R = 'running'
-    running = strawberry.enum_value('running')
-    C = 'completed'
-    completed = strawberry.enum_value('completed')
-    F = 'failed'
-    failed = strawberry.enum_value('failed')
-    S = 'suspended'
+    R = 'R'
+    running = strawberry.enum_value('R')
+    C = 'C'
+    completed = strawberry.enum_value('C')
+    F = 'F'
+    failed = strawberry.enum_value('F')
+    S = 'S'
     suspended = strawberry.enum_value('suspended')
 
-    pending = strawberry.enum_value('running', deprecation_reason="Changed to `running`")
-    success = strawberry.enum_value('completed', deprecation_reason="Changed to `completed`")
-    error = strawberry.enum_value('error', deprecation_reason="Changed to `failed`")
+    # Deprecations, to be removed in 0.4.0
+    pending = strawberry.enum_value('R', deprecation_reason="Pending is now running")
+    success = strawberry.enum_value('C', deprecation_reason="Success is now completed")
+    error = strawberry.enum_value('F', deprecation_reason="Error is now failed")
 
 
 # @strawberry.type
@@ -92,7 +93,7 @@ class Status(Enum):
 
 @strawberry.type
 class Process:
-    status: Status = Status.pending
+    status: Status = Status.running
     status_desc: str | None = None
     error_type: str | None = None
     error_desc: str | None = None
@@ -163,7 +164,7 @@ async def serialize(data: dict) -> dict:
         if isinstance(v, _BaseVersion):
             data[k] = str(v)
         elif isinstance(v, Enum):
-            data[k] = v.name
+            data[k] = v.value
         # datetime ok?
         elif isinstance(v, (Context, Process)):
             data[k] = await serialize(v.__dict__)

--- a/stable-requirements.txt
+++ b/stable-requirements.txt
@@ -1,0 +1,8 @@
+aiohttp==3.8.3
+asyncpg==0.27.0
+fastapi==0.88.0
+redis==4.4.0
+sqlalchemy==1.4.45
+starlette==0.22.0
+strawberry-graphql==0.151.0
+.


### PR DESCRIPTION
I'm not sure exactly when this change happened, but using the latest strawberry-graphql is resulting in 

```
sqlalchemy.exc.DBAPIError: (sqlalchemy.dialects.postgresql.asyncpg.Error) <class 'asyncpg.exceptions.InvalidTextRepresentationError'>: invalid input value for enum status: "pending"
```

This restructures `strawberry.enum` classes to produce a constant value, which is then called when serializing `Project` to be inserted in the database.

This also sneaks in a `stable-requirements.txt` to at least keep track of compatible versions during more stringent testing.