### PR TITLE
RF: Build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,14 @@
-.PHONY: compose-up compose-down freeze release-gcp
+.PHONY: docker-build compose-up compose-down freeze release-gcp
 
 BUILDTYPE=latest
 DEPLOYSERVER=uvicorn
+VERSION=$(shell hatch version 2> /dev/null | tail -n1)
 
-compose-up:
-	docker compose build --build-arg BUILDTYPE=$(BUILDTYPE) --build-arg DEPLOYSERVER=$(DEPLOYSERVER) --build-arg VERSION=`hatch version`
+docker-build:
+	@[ -n "$(VERSION)" ] || { echo "hatch was unable to find version - is it installed?"; exit 1; }
+	docker build --tag migas:latest --build-arg BUILDTYPE=$(BUILDTYPE) --build-arg DEPLOYSERVER=$(DEPLOYSERVER) --build-arg VERSION=$(VERSION) .
+
+compose-up: docker-build
 	docker compose up --detach
 
 compose-down:

--- a/deploy/docker/install.sh
+++ b/deploy/docker/install.sh
@@ -1,22 +1,24 @@
 #!/bin/env bash
 
+set -e
+
 BUILDTYPE=$1
 DEPLOYSERVER=$2
 
 # First update pip
-pip install --no-cache-dir pip
+python -m pip install --no-cache-dir pip
 
 case $BUILDTYPE in
 release)
-    pip install --no-cache-dir pip-tools
-    pip-sync stable-requirements.txt
-    pip install --no-cache-dir /src
+    python -m pip install --no-cache-dir pip-tools
+    python -m pip-sync stable-requirements.txt
+    python -m pip install --no-cache-dir /src
     ;;
 latest)
-    pip install --no-cache-dir /src
+    python -m pip install --no-cache-dir /src
     ;;
 latest-test)
-    pip install --no-cache-dir /src[test]
+    python -m pip install --no-cache-dir /src[test]
     ;;
 *)
     echo "Unknown command"
@@ -25,5 +27,5 @@ latest-test)
 esac
 
 if [ "$DEPLOYSERVER" = "gunicorn" ]; then
-    pip install --no-cache-dir gunicorn
+    python -m pip install --no-cache-dir gunicorn
 fi

--- a/deploy/docker/run.sh
+++ b/deploy/docker/run.sh
@@ -24,10 +24,10 @@ gunicorn)
     DEFAULT_GUNICORN_CONF=/src/deploy/docker/gunicorn_conf.py
     export GUNICORN_CONF=${GUNICORN_CONF:-$DEFAULT_GUNICORN_CONF}
     export WORKER_CLASS=${WORKER_CLASS:-"uvicorn.workers.UvicornWorker"}
-    CMD="gunicorn -k $WORKER_CLASS -c $GUNICORN_CONF $APP_MODULE"
+    CMD="python -m gunicorn -k $WORKER_CLASS -c $GUNICORN_CONF $APP_MODULE"
     ;;
 uvicorn)
-    CMD="uvicorn $APP_MODULE $@"
+    CMD="python -m uvicorn $APP_MODULE $@"
     ;;
 *)
     echo "No deployment server was specified"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     networks:
       - migas
     command:
-      --proxy-headers --port 8080 --host 0.0.0.0
+      --proxy-headers --port 8080 --host 0.0.0.0 --header X-Backend-Server:migas
     environment:
       MIGAS_REDIS_URI: "redis://cache:6379"
       DATABASE_URL: "postgresql+asyncpg://postgres:crumbs@postgres:5432/migas"

--- a/migas/server/database.py
+++ b/migas/server/database.py
@@ -119,7 +119,7 @@ async def query_usage_by_datetimes(
     async with gen_session() as session:
         # break up into 2 SELECT calls
         subq = (
-            select((project.c.timestamp, project.c.user_id))
+            select(project.c['timestamp', 'user_id'])
             .where(project.c.timestamp.between(start, end))
             .subquery()
         )


### PR DESCRIPTION
- Adds expected `X-Backend-Server:migas` header to docker-compose command.
- Exits upon early if the `pip install ...` build step fails
- Adds separate make command for building the server docker image

Also sneaking in a fix for `get_usage`, which will likely be reworked/removed in a future release.