### PR TITLE
RF: session decorator

### DIFF
--- a/migas/server/database.py
+++ b/migas/server/database.py
@@ -13,8 +13,13 @@ def db_context(func):
     """Decorator that creates a session for database interaction."""
     @wraps(func)
     async def wrapper(*args, **kwargs):
+        has_session = kwargs.get('session')
+        if has_session:
+            return await func(*args, **kwargs)
+        # no session specified, inject a new one
         async with gen_session() as session:
-            return await func(*args, session=session, **kwargs)
+            kwargs['session'] = session
+            return await func(*args, **kwargs)
     return wrapper
 
 

--- a/migas/server/models.py
+++ b/migas/server/models.py
@@ -155,9 +155,10 @@ async def init_db(engine: AsyncEngine) -> None:
         # create all tables
         await conn.run_sync(Base.metadata.create_all)
 
+SessionGen = AsyncGenerator[AsyncSession, None]
 
 @asynccontextmanager
-async def gen_session() -> AsyncGenerator[AsyncSession, None]:
+async def gen_session() -> SessionGen:
     """Generate a database session, and close once finished."""
     from .connections import get_db_engine
 


### PR DESCRIPTION
Many database operations included boilerplate context manager code - this strips it out as a decorator, and also adds the potential to pass in a session for multiple atomic transactions