### PR TITLE
FEAT: Re-add user localization

### DIFF
--- a/migas/server/app.py
+++ b/migas/server/app.py
@@ -16,6 +16,7 @@ from .connections import (
     get_redis_connection,
     get_requests_session,
 )
+from .fetchers import fetch_loc_dbs
 from .models import init_db
 from .schema import SCHEMA
 
@@ -31,7 +32,7 @@ async def lifespan(
     app.cache = await get_redis_connection()
     # Connect to PostgreSQL and initialize tables
     app.db = await get_db_engine()
-    await init_db(app.db)
+    await init_db()
     # Establish aiohttp session
     app.requests = await get_requests_session()
     if on_startup:
@@ -93,4 +94,4 @@ def create_app(lifespan_func=lifespan, **lifespan_kwargs) -> FastAPI:
     return app
 
 
-app = create_app()
+app = create_app(on_startup=fetch_loc_dbs)

--- a/migas/server/connections.py
+++ b/migas/server/connections.py
@@ -2,7 +2,7 @@
 
 import os
 
-import aiohttp
+from aiohttp import ClientSession, ClientTimeout
 import redis.asyncio as redis
 from sqlalchemy.ext.asyncio import AsyncEngine
 
@@ -45,13 +45,13 @@ async def get_redis_connection() -> redis.Redis:
 
 
 # GH requests
-async def get_requests_session() -> aiohttp.ClientSession:
+async def get_requests_session() -> ClientSession:
     """Initialize within an async function, since sync initialization is deprecated."""
     global REQUESTS_SESSION
     if REQUESTS_SESSION is None:
         print("Creating new aiohttp session")
-        REQUESTS_SESSION = aiohttp.ClientSession(
-            timeout=aiohttp.ClientTimeout(total=3),  # maximum wait time for a request
+        REQUESTS_SESSION = ClientSession(
+            timeout=ClientTimeout(total=3),  # maximum wait time for a request
             headers={'Content-Type': 'application/json'},
         )
     return REQUESTS_SESSION

--- a/migas/server/connections.py
+++ b/migas/server/connections.py
@@ -1,10 +1,13 @@
 """Module to faciliate connections to migas's helper services"""
 
 import os
+from functools import wraps
+from contextlib import asynccontextmanager
+from typing import AsyncGenerator
 
 from aiohttp import ClientSession, ClientTimeout
 import redis.asyncio as redis
-from sqlalchemy.ext.asyncio import AsyncEngine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 try:  # do not define unless necessary, to avoid overwriting established sessions
     MEM_CACHE
@@ -52,7 +55,6 @@ async def get_requests_session() -> ClientSession:
         print("Creating new aiohttp session")
         REQUESTS_SESSION = ClientSession(
             timeout=ClientTimeout(total=3),  # maximum wait time for a request
-            headers={'Content-Type': 'application/json'},
         )
     return REQUESTS_SESSION
 
@@ -89,3 +91,88 @@ async def get_db_engine() -> AsyncEngine:
             echo=bool(os.getenv("MIGAS_DEBUG")),
         )
     return DB_ENGINE
+
+
+@asynccontextmanager
+async def gen_session() -> AsyncGenerator[AsyncSession, None]:
+    """Generate a database session, and close once finished."""
+    from .connections import get_db_engine
+
+    # do not expire on commit to allow use of data afterwards
+    session = AsyncSession(await get_db_engine(), future=True, expire_on_commit=False)
+    try:
+        yield session
+        await session.commit()
+    except Exception as e:
+        await session.rollback()
+        print(f"Transaction failed. Rolling back the session. Error: {e}")
+    finally:
+        await session.close()
+
+def inject_sync_conn(func):
+    """
+    Decorator to run async database functions synchronously.
+    """
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        conn = kwargs.get('conn')
+        if conn:
+            return await conn.run_sync(func, *args, **kwargs)
+
+        engine = await get_db_engine()
+        async with engine.begin() as conn:
+            return await conn.run_sync(func, *args, **kwargs)
+    return wrapper
+
+
+def inject_db_conn(func):
+    """
+    Decorator that creates a connection.
+
+    Generally used when ORM mapping is not needed.
+    """
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        conn = kwargs.get('conn')
+        if conn:
+            return await func(*args, **kwargs)
+
+        engine = await get_db_engine()
+        async with engine.begin() as conn:
+            return await func(*args, conn=conn, **kwargs)
+    return wrapper
+
+
+def inject_db_session(func):
+    """
+    Decorator that creates a session for database interaction.
+
+    This is generally used when working with ORM level transactions.
+    """
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        cur_session = kwargs.get('session')
+        if cur_session:
+            # if chaining, committing and closing need to be handled
+            return await func(*args, **kwargs)
+
+        async with gen_session() as session:
+            return await func(*args, session=session, **kwargs)
+    return wrapper
+
+
+def inject_aiohttp_session(func):
+    """
+    Decorator that ensures an aiohttp session is provided.
+
+    Will default to use the global application session, unless one is provided.
+    """
+    @wraps(func)
+    async def wrapper(*args, **kwargs):
+        session = kwargs.pop('session', None)
+        if not session:
+            from .connections import get_requests_session
+
+            session = await get_requests_session()
+        return await func(*args, session=session, **kwargs)
+    return wrapper

--- a/migas/server/constants.py
+++ b/migas/server/constants.py
@@ -1,0 +1,3 @@
+# TODO: Add integrity hash
+LOC_ASN_URL = 'https://osf.io/download/qzmpu/'
+LOC_CITY_URL = 'https://osf.io/download/686db8fa4c0173d9ef03a8e6/'

--- a/migas/server/fetchers.py
+++ b/migas/server/fetchers.py
@@ -91,9 +91,9 @@ async def fetch_project_info(project: str) -> dict:
 
 
 @inject_aiohttp_session
-async def fetch_gzipped_file(url: str, *, session: ClientSession) -> bytes | None:
+async def fetch_gzipped_file(url: str, *, timeout: int = 60, session: ClientSession) -> bytes | None:
     """Get the already processed database file"""
-    async with session.get(url, timeout=60) as resp:
+    async with session.get(url, timeout=timeout) as resp:
         if resp.status != 200:
             return
         content = await resp.read()

--- a/migas/server/models.py
+++ b/migas/server/models.py
@@ -4,9 +4,9 @@ from typing import AsyncGenerator
 from sqlalchemy import Column, MetaData, Table
 from sqlalchemy.dialects.postgresql import ENUM, UUID
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
-from sqlalchemy.orm import declarative_base, relationship
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import func
-from sqlalchemy.types import BOOLEAN, INTEGER, TIMESTAMP, String
+from sqlalchemy.types import BOOLEAN, INTEGER, TIMESTAMP, String, BIGINT, CHAR, DOUBLE_PRECISION
 
 SCHEMA = 'migas'
 
@@ -55,6 +55,29 @@ class Authentication(Base):
     __tablename__ = "auth"
     project = Column(String(length=140), primary_key=True)
     token = Column(String)
+
+
+class LocASN(Base):
+    __tablename__ = 'loc_asn'
+    idx = Column(BIGINT, primary_key=True)
+    start_ip = Column(BIGINT, nullable=False)
+    end_ip = Column(BIGINT, nullable=False)
+    asn = Column(INTEGER)
+    asn_org = Column(String)
+
+
+class LocCity(Base):
+    __tablename__ = 'loc_city'
+    idx = Column(BIGINT, primary_key=True)
+    start_ip = Column(BIGINT, nullable=False)
+    end_ip = Column(BIGINT, nullable=False)
+    continent_code = Column(CHAR(2))
+    country_code = Column(CHAR(2))
+    state_province_name = Column(String)
+    city_name = Column(String)
+    lat = Column(DOUBLE_PRECISION)
+    lon = Column(DOUBLE_PRECISION)
+
 
 
 async def get_project_tables(project: str, create: bool = False) -> tuple[Table, Table]:
@@ -155,10 +178,9 @@ async def init_db(engine: AsyncEngine) -> None:
         # create all tables
         await conn.run_sync(Base.metadata.create_all)
 
-SessionGen = AsyncGenerator[AsyncSession, None]
 
 @asynccontextmanager
-async def gen_session() -> SessionGen:
+async def gen_session() -> AsyncGenerator[AsyncSession, None]:
     """Generate a database session, and close once finished."""
     from .connections import get_db_engine
 

--- a/migas/server/models.py
+++ b/migas/server/models.py
@@ -2,11 +2,11 @@ from contextlib import asynccontextmanager
 from typing import AsyncGenerator
 
 from sqlalchemy import Column, MetaData, Table
-from sqlalchemy.dialects.postgresql import ENUM, UUID
+from sqlalchemy.dialects.postgresql import ENUM, UUID, INET
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import func
-from sqlalchemy.types import BOOLEAN, INTEGER, TIMESTAMP, String, BIGINT, CHAR, DOUBLE_PRECISION
+from sqlalchemy.types import BOOLEAN, INTEGER, TIMESTAMP, String, CHAR, DOUBLE_PRECISION
 
 SCHEMA = 'migas'
 
@@ -46,6 +46,8 @@ class ProjectUsers(Base):
     user_type = Column(String(length=7), nullable=False)
     platform = Column(String(length=8))
     container = Column(String(length=9), nullable=False)
+    asn_idx = Column(INTEGER)
+    city_idx = Column(INTEGER)
 
 
 projects = Projects.__table__
@@ -59,18 +61,18 @@ class Authentication(Base):
 
 class LocASN(Base):
     __tablename__ = 'loc_asn'
-    idx = Column(BIGINT, primary_key=True)
-    start_ip = Column(BIGINT, nullable=False)
-    end_ip = Column(BIGINT, nullable=False)
+    idx = Column(INTEGER, primary_key=True)
+    start_ip = Column(INET, nullable=False)
+    end_ip = Column(INET, nullable=False)
     asn = Column(INTEGER)
     asn_org = Column(String)
 
 
 class LocCity(Base):
     __tablename__ = 'loc_city'
-    idx = Column(BIGINT, primary_key=True)
-    start_ip = Column(BIGINT, nullable=False)
-    end_ip = Column(BIGINT, nullable=False)
+    idx = Column(INTEGER, primary_key=True)
+    start_ip = Column(INET, nullable=False)
+    end_ip = Column(INET, nullable=False)
     continent_code = Column(CHAR(2))
     country_code = Column(CHAR(2))
     state_province_name = Column(String)

--- a/migas/server/models.py
+++ b/migas/server/models.py
@@ -1,12 +1,13 @@
-from contextlib import asynccontextmanager
-from typing import AsyncGenerator
+import typing as ty
 
-from sqlalchemy import Column, MetaData, Table
+from sqlalchemy import Column, MetaData, Table, text
 from sqlalchemy.dialects.postgresql import ENUM, UUID, INET
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncConnection
 from sqlalchemy.orm import declarative_base
 from sqlalchemy.sql import func
 from sqlalchemy.types import BOOLEAN, INTEGER, TIMESTAMP, String, CHAR, DOUBLE_PRECISION
+
+from .connections import inject_db_conn
 
 SCHEMA = 'migas'
 
@@ -136,24 +137,21 @@ async def get_project_tables(project: str, create: bool = False) -> tuple[Table,
     return project_table, users_table
 
 
-async def create_tables(tables: list) -> None:
-    from .connections import get_db_engine
-
-    engine = await get_db_engine()
-    async with engine.begin() as conn:
-        def _create_tables(conn) -> None:
-            return Base.metadata.create_all(conn, tables=tables)
-        await conn.run_sync(_create_tables)
+@inject_db_conn
+async def create_tables(tables: list, conn: AsyncConnection) -> None:
+    def _create_tables(conn) -> None:
+        return Base.metadata.create_all(conn, tables=tables)
+    await conn.run_sync(_create_tables)
 
 
+@inject_db_conn
 async def populate_base(conn: AsyncConnection) -> None:
     """Populate declarative class definitions with dynamically created tables."""
 
     def _has_master_table(conn) -> bool:
         from sqlalchemy import inspect
 
-        inspector = inspect(conn)
-        return inspector.has_table("projects", schema='migas')
+        return inspect(conn).has_table('projects', schema=SCHEMA)
 
     if await conn.run_sync(_has_master_table):
         from .database import query_projects
@@ -162,7 +160,8 @@ async def populate_base(conn: AsyncConnection) -> None:
             await get_project_tables(project)
 
 
-async def init_db(engine: AsyncEngine) -> None:
+@inject_db_conn
+async def init_db(conn: AsyncConnection) -> None:
     """
     Initialize the database.
 
@@ -171,28 +170,48 @@ async def init_db(engine: AsyncEngine) -> None:
     2) project tables
     3) If projects table exists, ensure all tracked projects have Project/ProjectUsers tables.
     """
-    async with engine.begin() as conn:
-        from sqlalchemy.schema import CreateSchema
-        await conn.execute(CreateSchema('migas', if_not_exists=True))
+    from sqlalchemy.schema import CreateSchema
+    await conn.execute(CreateSchema('migas', if_not_exists=True))
 
-        # if project is already being monitored, create it
-        await populate_base(conn)
-        # create all tables
-        await conn.run_sync(Base.metadata.create_all)
+    # if project is already being monitored, create it
+    await populate_base(conn=conn)
+    # create all tables
+    await conn.run_sync(Base.metadata.create_all)
 
 
-@asynccontextmanager
-async def gen_session() -> AsyncGenerator[AsyncSession, None]:
-    """Generate a database session, and close once finished."""
-    from .connections import get_db_engine
+@inject_db_conn
+async def copy_db_from_stream(
+    file_bytes: bytes,
+    db: ty.Literal['asn', 'city'],
+    conn: AsyncConnection,
+):
+    """
+    Write bytes to a table.
+    """
+    import io
 
-    # do not expire on commit to allow use of data afterwards
-    session = AsyncSession(await get_db_engine(), future=True, expire_on_commit=False)
-    try:
-        yield session
-        await session.commit()
-    except Exception as e:
-        await session.rollback()
-        print(f"Transaction failed. Rolling back the session. Error: {e}")
-    finally:
-        await session.close()
+    match db:
+        case 'asn':
+            table = LocASN
+        case 'city':
+            table = LocCity
+        case _:
+            return
+
+    tablename = table.__tablename__
+    columns = [c.name for c in table.__table__.columns if c.name != 'idx']
+    raw_conn = await conn.get_raw_connection()
+
+    with io.BytesIO(file_bytes) as stream:
+        try:
+            # asyncpg-specific method
+            await raw_conn.driver_connection.copy_to_table(
+                table_name=tablename,
+                source=stream,
+                columns=columns,
+                schema_name=SCHEMA,
+                format='csv',
+                header=False,
+            )
+        except Exception as e:
+            print(f'Error when copying to {db}: {e}')

--- a/migas/server/schema.py
+++ b/migas/server/schema.py
@@ -184,8 +184,10 @@ class Mutation:
             process=process,
         )
 
+        request = info.context['request']
+        ip = request.client.host
         bg_tasks = info.context['background_tasks']
-        bg_tasks.add_task(ingest_project, project)
+        bg_tasks.add_task(ingest_project, project, ip)
         return BreadcrumbResult(success=True)
 
 
@@ -224,9 +226,11 @@ class Mutation:
 
         fetched = await fetch_project_info(p.project)
 
+        request = info.context['request']
+        ip = request.client.host
         # return project info ASAP, assign data ingestion as background tasks
         bg_tasks = info.context['background_tasks']
-        bg_tasks.add_task(ingest_project, project)
+        bg_tasks.add_task(ingest_project, project, ip)
 
         return {
             'bad_versions': fetched['bad_versions'],


### PR DESCRIPTION
Addresses https://github.com/nipreps/migas-py/issues/54

This re-enables the geolocation of incoming requests, with some changes from the previous implementation:
- Rather than sending specific IPs to a service and storing previous results, use an IP lookup table ([DB-IP](https://db-ip.com/db/lite.php)). This saves us from needing to either 1) pay for a service if we exceed X requests and 2) cache IPs in some persistent storage.

ATM, this is disabled by default (downloading the location CSVs can be expensive on application boot), but can be enabled by setting `MIGAS_DOWNLOAD_LOCATION` to some value.